### PR TITLE
Visualize gif clip start and end cropping

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,6 +70,108 @@ function formatSeconds(sec: number): string {
   return `${m}:${s.toString().padStart(2, '0')}`;
 }
 
+interface TimelineProps {
+  duration: number;
+  start: number;
+  end: number;
+  onStartChange: (start: number) => void;
+  onEndChange: (end: number) => void;
+}
+
+function Timeline({ duration, start, end, onStartChange, onEndChange }: TimelineProps) {
+  const timelineRef = useRef<HTMLDivElement>(null);
+  const [isDragging, setIsDragging] = useState<'start' | 'end' | null>(null);
+
+  const handleMouseDown = (e: React.MouseEvent, type: 'start' | 'end') => {
+    e.preventDefault();
+    setIsDragging(type);
+  };
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (!isDragging || !timelineRef.current) return;
+    
+    const rect = timelineRef.current.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const percentage = Math.max(0, Math.min(1, x / rect.width));
+    const time = percentage * duration;
+    
+    if (isDragging === 'start') {
+      onStartChange(Math.min(time, end - 0.1));
+    } else {
+      onEndChange(Math.max(time, start + 0.1));
+    }
+  };
+
+  const handleMouseUp = () => {
+    setIsDragging(null);
+  };
+
+  const handleTimelineClick = (e: React.MouseEvent) => {
+    if (!timelineRef.current) return;
+    
+    const rect = timelineRef.current.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const percentage = Math.max(0, Math.min(1, x / rect.width));
+    const time = percentage * duration;
+    
+    // If clicked closer to start, move start; otherwise move end
+    const startDistance = Math.abs(time - start);
+    const endDistance = Math.abs(time - end);
+    
+    if (startDistance < endDistance) {
+      onStartChange(Math.min(time, end - 0.1));
+    } else {
+      onEndChange(Math.max(time, start + 0.1));
+    }
+  };
+
+  const startPercentage = (start / duration) * 100;
+  const endPercentage = (end / duration) * 100;
+  const selectedWidth = endPercentage - startPercentage;
+
+  return (
+    <div className="timeline-container">
+      <div className="timeline-labels">
+        <span>0:00</span>
+        <span>{formatSeconds(duration)}</span>
+      </div>
+      <div 
+        ref={timelineRef}
+        className="timeline"
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
+        onClick={handleTimelineClick}
+      >
+        <div className="timeline-track">
+          <div 
+            className="timeline-selected"
+            style={{
+              left: `${startPercentage}%`,
+              width: `${selectedWidth}%`
+            }}
+          />
+          <div 
+            className="timeline-handle timeline-handle-start"
+            style={{ left: `${startPercentage}%` }}
+            onMouseDown={(e) => handleMouseDown(e, 'start')}
+          />
+          <div 
+            className="timeline-handle timeline-handle-end"
+            style={{ left: `${endPercentage}%` }}
+            onMouseDown={(e) => handleMouseDown(e, 'end')}
+          />
+        </div>
+      </div>
+      <div className="timeline-info">
+        <span>Start: {formatSeconds(start)}</span>
+        <span>End: {formatSeconds(end)}</span>
+        <span>Duration: {formatSeconds(end - start)}</span>
+      </div>
+    </div>
+  );
+}
+
 export default function App() {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const [file, setFile] = useState<File | null>(null);
@@ -186,31 +288,16 @@ export default function App() {
               <video ref={videoRef} src={objectUrl ?? undefined} controls playsInline style={{ width: '100%' }} />
               <div className="spacer" />
               <div className="card">
-                <div className="row">
-                  <label>Start: {formatSeconds(start)}</label>
-                  <input
-                    type="range"
-                    min={0}
-                    max={Math.max(0, duration - 0.1)}
-                    step={0.1}
-                    value={Math.min(start, end)}
-                    onChange={(e) => setStart(Math.min(parseFloat(e.target.value), end))}
-                  />
-                </div>
-                <div className="row">
-                  <label>End: {formatSeconds(end)}</label>
-                  <input
-                    type="range"
-                    min={start + 0.1}
-                    max={duration}
-                    step={0.1}
-                    value={end}
-                    onChange={(e) => setEnd(Math.max(parseFloat(e.target.value), start + 0.1))}
-                  />
-                </div>
+                <Timeline
+                  duration={duration}
+                  start={start}
+                  end={end}
+                  onStartChange={setStart}
+                  onEndChange={setEnd}
+                />
                 <div className="row">
                   <small>
-                    Segment length: {formatSeconds(Math.max(0, end - start))} • Estimated frames: {estimatedFrames}
+                    Estimated frames: {estimatedFrames}
                   </small>
                 </div>
               </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -13,3 +13,82 @@ input[type="range"] { width: 100%; }
 video, canvas, img { max-width: 100%; border-radius: 8px; }
 .progress { height: 8px; background: color-mix(in srgb, CanvasText 10%, transparent); border-radius: 999px; overflow: hidden; }
 .progress > div { height: 100%; background: #10b981; width: 0%; }
+
+/* Timeline Component Styles */
+.timeline-container {
+  margin: 16px 0;
+}
+
+.timeline-labels {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 8px;
+  font-size: 12px;
+  color: color-mix(in srgb, CanvasText 70%, transparent);
+}
+
+.timeline {
+  position: relative;
+  height: 40px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.timeline-track {
+  position: relative;
+  height: 8px;
+  background: color-mix(in srgb, CanvasText 15%, transparent);
+  border-radius: 4px;
+  margin: 16px 0;
+}
+
+.timeline-selected {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  background: #2563eb;
+  border-radius: 4px;
+  pointer-events: none;
+}
+
+.timeline-handle {
+  position: absolute;
+  top: -6px;
+  width: 20px;
+  height: 20px;
+  background: #2563eb;
+  border: 2px solid white;
+  border-radius: 50%;
+  cursor: grab;
+  transform: translateX(-50%);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.timeline-handle:active {
+  cursor: grabbing;
+}
+
+.timeline-handle:hover {
+  transform: translateX(-50%) scale(1.1);
+  transition: transform 0.1s ease;
+}
+
+.timeline-handle-start {
+  z-index: 2;
+}
+
+.timeline-handle-end {
+  z-index: 2;
+}
+
+.timeline-info {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 8px;
+  font-size: 12px;
+  color: color-mix(in srgb, CanvasText 70%, transparent);
+}
+
+.timeline-info span {
+  font-weight: 500;
+}


### PR DESCRIPTION
Introduce a visual timeline component to intuitively select GIF clip start and end times, replacing basic range sliders.

This change addresses the user's request for a visual representation of the video segment being cropped, making it easier to understand and adjust the GIF's duration and content.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f9fd8f0-6a2e-41c8-bf83-8cb2931217d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0f9fd8f0-6a2e-41c8-bf83-8cb2931217d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

