### PR TITLE
Enable video sharing from other apps

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,5 +8,26 @@
   "theme_color": "#0f172a",
   "icons": [
     { "src": "/icons/app-icon.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any maskable" }
-  ]
+  ],
+  "file_handlers": [
+    {
+      "action": ".",
+      "accept": {
+        "video/*": [".mp4", ".mov", ".avi", ".webm", ".mkv", ".m4v", ".3gp", ".flv", ".wmv"]
+      }
+    }
+  ],
+  "share_target": {
+    "action": ".",
+    "method": "POST",
+    "enctype": "multipart/form-data",
+    "params": {
+      "files": [
+        {
+          "name": "video",
+          "accept": ["video/*"]
+        }
+      ]
+    }
+  }
 }

--- a/share-target.html
+++ b/share-target.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GIF Maker - Processing Shared Video</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: #0f172a;
+            color: white;
+            margin: 0;
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+        }
+        .container {
+            text-align: center;
+            max-width: 400px;
+        }
+        .spinner {
+            border: 4px solid #374151;
+            border-top: 4px solid #10b981;
+            border-radius: 50%;
+            width: 40px;
+            height: 40px;
+            animation: spin 1s linear infinite;
+            margin: 20px auto;
+        }
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+        .success {
+            color: #10b981;
+            font-weight: bold;
+        }
+        .error {
+            color: #ef4444;
+            font-weight: bold;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>GIF Maker</h1>
+        <div id="status">
+            <div class="spinner"></div>
+            <p>Processing shared video...</p>
+        </div>
+    </div>
+
+    <script>
+        // Handle the shared video file
+        async function handleSharedVideo() {
+            try {
+                // Get the shared file from the form data
+                const formData = new FormData();
+                const response = await fetch(window.location.href, {
+                    method: 'POST',
+                    body: formData
+                });
+
+                if (response.ok) {
+                    // Redirect to the main app with the shared file
+                    window.location.href = '/?shared=true';
+                } else {
+                    throw new Error('Failed to process shared video');
+                }
+            } catch (error) {
+                console.error('Error handling shared video:', error);
+                document.getElementById('status').innerHTML = `
+                    <div class="error">❌ Error processing video</div>
+                    <p>Please try sharing the video again or use the file picker.</p>
+                    <button onclick="window.location.href='/'" style="
+                        background: #10b981;
+                        color: white;
+                        border: none;
+                        padding: 10px 20px;
+                        border-radius: 5px;
+                        cursor: pointer;
+                        margin-top: 10px;
+                    ">Go to GIF Maker</button>
+                `;
+            }
+        }
+
+        // Check if this is a POST request (share target)
+        if (window.location.search.includes('shared=true')) {
+            document.getElementById('status').innerHTML = `
+                <div class="success">✅ Video received!</div>
+                <p>Redirecting to GIF Maker...</p>
+            `;
+            setTimeout(() => {
+                window.location.href = '/';
+            }, 1000);
+        } else {
+            // Handle the share target POST
+            handleSharedVideo();
+        }
+    </script>
+</body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -186,6 +186,7 @@ export default function App() {
   const [progress, setProgress] = useState<number>(0);
   const [gifUrl, setGifUrl] = useState<string | null>(null);
   const [isEncoding, setIsEncoding] = useState<boolean>(false);
+  const [isSharedFile, setIsSharedFile] = useState<boolean>(false);
   const { encode } = useFfmpegWorker();
 
   useEffect(() => {
@@ -206,6 +207,117 @@ export default function App() {
     v.addEventListener('loadedmetadata', onLoaded);
     return () => v.removeEventListener('loadedmetadata', onLoaded);
   }, [objectUrl]);
+
+  // Handle file sharing and file handling
+  useEffect(() => {
+    // Check if the app was opened via share target
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get('shared') === 'true') {
+      setIsSharedFile(true);
+      // Retrieve the shared file from IndexedDB
+      retrieveSharedFile();
+    }
+
+    // Handle file sharing from other apps
+    const handleFileShare = (event: MessageEvent) => {
+      if (event.data && event.data.type === 'SHARED_VIDEO' && event.data.file) {
+        setFile(event.data.file);
+        setIsSharedFile(true);
+      }
+    };
+
+    // Listen for messages from service worker
+    navigator.serviceWorker?.addEventListener('message', handleFileShare);
+
+    // Handle file opening via file handlers
+    const handleFileOpen = (event: Event) => {
+      const customEvent = event as CustomEvent;
+      if (customEvent.detail && customEvent.detail.file) {
+        setFile(customEvent.detail.file);
+        setIsSharedFile(true);
+      }
+    };
+
+    // Listen for custom file open events
+    window.addEventListener('file-open', handleFileOpen as EventListener);
+
+    // Handle drag and drop for files
+    const handleDragOver = (e: DragEvent) => {
+      e.preventDefault();
+      e.dataTransfer!.dropEffect = 'copy';
+    };
+
+    const handleDrop = (e: DragEvent) => {
+      e.preventDefault();
+      const files = e.dataTransfer?.files;
+      if (files && files.length > 0) {
+        const videoFile = Array.from(files).find(f => f.type.startsWith('video/'));
+        if (videoFile) {
+          setFile(videoFile);
+          setIsSharedFile(false);
+        }
+      }
+    };
+
+    document.addEventListener('dragover', handleDragOver);
+    document.addEventListener('drop', handleDrop);
+
+    return () => {
+      navigator.serviceWorker?.removeEventListener('message', handleFileShare);
+      window.removeEventListener('file-open', handleFileOpen as EventListener);
+      document.removeEventListener('dragover', handleDragOver);
+      document.removeEventListener('drop', handleDrop);
+    };
+  }, []);
+
+  // Retrieve shared file from IndexedDB
+  const retrieveSharedFile = async () => {
+    try {
+      const request = indexedDB.open('GIFMakerDB', 1);
+      
+      request.onerror = () => {
+        console.error('Failed to open IndexedDB');
+      };
+      
+      request.onsuccess = () => {
+        const db = request.result;
+        const transaction = db.transaction(['sharedFiles'], 'readonly');
+        const store = transaction.objectStore('sharedFiles');
+        const getAllRequest = store.getAll();
+        
+        getAllRequest.onsuccess = () => {
+          const files = getAllRequest.result;
+          if (files.length > 0) {
+            // Get the most recent file
+            const latestFile = files.sort((a, b) => b.timestamp.localeCompare(a.timestamp))[0];
+            setFile(latestFile.file);
+          }
+        };
+        
+        getAllRequest.onerror = () => {
+          console.error('Failed to retrieve shared file');
+        };
+      };
+      
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains('sharedFiles')) {
+          db.createObjectStore('sharedFiles', { keyPath: 'id' });
+        }
+      };
+    } catch (error) {
+      console.error('Error retrieving shared file:', error);
+    }
+  };
+
+  // Handle file input changes
+  const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFile = e.target.files?.[0];
+    if (selectedFile && selectedFile.type.startsWith('video/')) {
+      setFile(selectedFile);
+      setIsSharedFile(false);
+    }
+  };
 
   const estimatedFrames = useMemo(() => {
     const len = Math.max(0, end - start);
@@ -293,19 +405,33 @@ export default function App() {
       onDrop={(e) => {
         e.preventDefault();
         const f = e.dataTransfer.files?.[0];
-        if (f && f.type.startsWith('video/')) setFile(f);
+        if (f && f.type.startsWith('video/')) {
+          setFile(f);
+          setIsSharedFile(false);
+        }
       }}
     >
       <h1>PWA GIF Maker</h1>
+      {isSharedFile && (
+        <div className="card" style={{ backgroundColor: '#10b981', color: 'white', marginBottom: '12px' }}>
+          <div style={{ fontWeight: 'bold' }}>
+            📱 Video received from another app!
+          </div>
+          <small>This video was shared to the GIF Maker app.</small>
+        </div>
+      )}
       <div className="card">
         <div className="row">
           <input
             type="file"
             accept="video/*"
-            onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+            onChange={handleFileInputChange}
           />
           {file && (
-            <button className="btn" onClick={() => setFile(null)}>Clear</button>
+            <button className="btn" onClick={() => {
+              setFile(null);
+              setIsSharedFile(false);
+            }}>Clear</button>
           )}
         </div>
         {objectUrl && (

--- a/sw.ts
+++ b/sw.ts
@@ -1,4 +1,4 @@
-// Minimal service worker for app shell caching
+// Service worker for app shell caching and file sharing
 const CACHE = 'app-cache-v1';
 const APP_SHELL = [
   '/',
@@ -31,4 +31,112 @@ self.addEventListener('fetch', (event: any) => {
     )
   );
 });
+
+// Handle file sharing and file handling
+self.addEventListener('message', (event: any) => {
+  if (event.data && event.data.type === 'SHARE_VIDEO') {
+    // Forward the shared video data to the main app
+    (self as any).clients.matchAll().then((clients: any[]) => {
+      clients.forEach((client) => {
+        client.postMessage({
+          type: 'SHARED_VIDEO',
+          file: event.data.file
+        });
+      });
+    });
+  }
+});
+
+// Handle share target (when app is opened via share)
+self.addEventListener('fetch', (event: any) => {
+  const url = new URL(event.request.url);
+  
+  // Handle share target POST requests
+  if (event.request.method === 'POST' && url.pathname === '/') {
+    event.respondWith(
+      event.request.formData().then((formData) => {
+        const file = formData.get('video') as File;
+        if (file && file.type.startsWith('video/')) {
+          // Store the shared file in IndexedDB and redirect to the app
+          return storeSharedFile(file).then(() => {
+            return new Response(null, {
+              status: 302,
+              headers: {
+                'Location': '/?shared=true'
+              }
+            });
+          });
+        }
+        return new Response('Invalid file type', { status: 400 });
+      }).catch(() => {
+        return new Response('Error processing shared file', { status: 500 });
+      })
+    );
+  }
+});
+
+// Store shared file in IndexedDB
+async function storeSharedFile(file: File): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open('GIFMakerDB', 1);
+    
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => {
+      const db = request.result;
+      const transaction = db.transaction(['sharedFiles'], 'readwrite');
+      const store = transaction.objectStore('sharedFiles');
+      
+      const fileData = {
+        id: Date.now(),
+        file: file,
+        timestamp: new Date().toISOString()
+      };
+      
+      store.add(fileData);
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+    };
+    
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains('sharedFiles')) {
+        db.createObjectStore('sharedFiles', { keyPath: 'id' });
+      }
+    };
+  });
+}
+
+// Retrieve shared file from IndexedDB
+async function getSharedFile(): Promise<File | null> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open('GIFMakerDB', 1);
+    
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => {
+      const db = request.result;
+      const transaction = db.transaction(['sharedFiles'], 'readonly');
+      const store = transaction.objectStore('sharedFiles');
+      const getAllRequest = store.getAll();
+      
+      getAllRequest.onsuccess = () => {
+        const files = getAllRequest.result;
+        if (files.length > 0) {
+          // Get the most recent file
+          const latestFile = files.sort((a, b) => b.timestamp.localeCompare(a.timestamp))[0];
+          resolve(latestFile.file);
+        } else {
+          resolve(null);
+        }
+      };
+      getAllRequest.onerror = () => reject(getAllRequest.error);
+    };
+    
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains('sharedFiles')) {
+        db.createObjectStore('sharedFiles', { keyPath: 'id' });
+      }
+    };
+  });
+}
 

--- a/test-sharing.html
+++ b/test-sharing.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test Video Sharing - GIF Maker</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: #0f172a;
+            color: white;
+            margin: 0;
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+        }
+        .container {
+            text-align: center;
+            max-width: 600px;
+        }
+        .card {
+            background: #1e293b;
+            border-radius: 8px;
+            padding: 20px;
+            margin: 20px 0;
+        }
+        .btn {
+            background: #10b981;
+            color: white;
+            border: none;
+            padding: 12px 24px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 16px;
+            margin: 10px;
+        }
+        .btn:hover {
+            background: #059669;
+        }
+        .btn:disabled {
+            background: #6b7280;
+            cursor: not-allowed;
+        }
+        .feature {
+            display: flex;
+            align-items: center;
+            margin: 10px 0;
+            padding: 10px;
+            background: #374151;
+            border-radius: 6px;
+        }
+        .feature-icon {
+            font-size: 24px;
+            margin-right: 15px;
+        }
+        .instructions {
+            text-align: left;
+            background: #1e293b;
+            padding: 20px;
+            border-radius: 8px;
+            margin: 20px 0;
+        }
+        .instructions ol {
+            margin: 10px 0;
+            padding-left: 20px;
+        }
+        .instructions li {
+            margin: 8px 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>🎬 GIF Maker - Video Sharing Test</h1>
+        
+        <div class="card">
+            <h2>✅ Video Sharing Features Added</h2>
+            <div class="feature">
+                <div class="feature-icon">📱</div>
+                <div>
+                    <strong>Share Target</strong><br>
+                    Other apps can share videos directly to GIF Maker
+                </div>
+            </div>
+            <div class="feature">
+                <div class="feature-icon">📁</div>
+                <div>
+                    <strong>File Handler</strong><br>
+                    Open video files directly in GIF Maker
+                </div>
+            </div>
+            <div class="feature">
+                <div class="feature-icon">🎯</div>
+                <div>
+                    <strong>Drag & Drop</strong><br>
+                    Drag videos from other apps or file manager
+                </div>
+            </div>
+        </div>
+
+        <div class="instructions">
+            <h3>How to Test Video Sharing:</h3>
+            <ol>
+                <li><strong>Install as PWA:</strong> Open the main app and install it as a PWA on your device</li>
+                <li><strong>Share from Gallery:</strong> Open your photo/video gallery, select a video, and tap "Share" → "GIF Maker"</li>
+                <li><strong>Open Video Files:</strong> In your file manager, tap on a video file and select "Open with GIF Maker"</li>
+                <li><strong>Drag & Drop:</strong> On desktop, drag video files from your file manager directly onto the app</li>
+            </ol>
+        </div>
+
+        <div class="card">
+            <h3>Test the App</h3>
+            <p>Click the button below to open the GIF Maker app and test the video sharing functionality:</p>
+            <button class="btn" onclick="window.open('/', '_blank')">
+                🚀 Open GIF Maker
+            </button>
+        </div>
+
+        <div class="card">
+            <h3>Supported Video Formats</h3>
+            <p>MP4, MOV, AVI, WebM, MKV, M4V, 3GP, FLV, WMV</p>
+        </div>
+
+        <div class="card">
+            <h3>What Happens When You Share a Video?</h3>
+            <ol style="text-align: left;">
+                <li>Video is automatically loaded into the app</li>
+                <li>You'll see a green notification confirming the video was received</li>
+                <li>Video player appears with timeline controls for cropping</li>
+                <li>Configure GIF settings (FPS, width, quality, loop)</li>
+                <li>Export your GIF and share it back!</li>
+            </ol>
+        </div>
+    </div>
+
+    <script>
+        // Check if the app is installed as PWA
+        if (window.matchMedia('(display-mode: standalone)').matches) {
+            document.querySelector('.instructions ol').innerHTML = `
+                <li><strong>Share from Gallery:</strong> Open your photo/video gallery, select a video, and tap "Share" → "GIF Maker"</li>
+                <li><strong>Open Video Files:</strong> In your file manager, tap on a video file and select "Open with GIF Maker"</li>
+                <li><strong>Drag & Drop:</strong> On desktop, drag video files from your file manager directly onto the app</li>
+            `;
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Add PWA share target and file handling capabilities to allow sharing videos from other apps for cropping and GIF conversion.

---
<a href="https://cursor.com/background-agent?bcId=bc-7db68fa8-baca-4929-837e-b3af5b30cee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7db68fa8-baca-4929-837e-b3af5b30cee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

