### PR TITLE
Resize and crop dragon for app and pwa icon

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="manifest" href="/assets/manifest-DcScJrdn-DcScJrdn.json" />
     <meta name="theme-color" content="#0f172a" />
-    <title>PWA GIF Maker</title>
+    <title>Giffer</title>
     <script type="module" crossorigin src="/assets/index-DuG9yJu4.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-WEmGWybu.css">
   </head>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="manifest" href="/assets/manifest-DcScJrdn-DcScJrdn.json" />
     <meta name="theme-color" content="#0f172a" />
-    <title>PWA GIF Maker</title>
+    <title>Giffer</title>
     <script type="module" crossorigin src="/assets/index-DuG9yJu4.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-WEmGWybu.css">
   </head>

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "PWA GIF Maker",
-  "short_name": "GIF Maker",
+  "name": "Giffer",
+  "short_name": "Giffer",
   "start_url": ".",
   "scope": ".",
   "display": "standalone",

--- a/public/icons/app-icon.svg
+++ b/public/icons/app-icon.svg
@@ -1,13 +1,60 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
   <defs>
-    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#1e293b" />
-      <stop offset="100%" stop-color="#0ea5e9" />
+    <!-- Dragon gradient -->
+    <linearGradient id="dragonBody" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#90EE90;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#32CD32;stop-opacity:1" />
+    </linearGradient>
+    
+    <!-- Dragon belly gradient -->
+    <linearGradient id="dragonBelly" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#FFFACD;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#F5DEB3;stop-opacity:1" />
     </linearGradient>
   </defs>
-  <rect width="256" height="256" rx="48" fill="url(#g)" />
-  <g fill="#fff">
-    <rect x="52" y="76" width="152" height="104" rx="12" fill-opacity="0.15" />
-    <path d="M84 92h72a12 12 0 0 1 12 12v48a12 12 0 0 1-12 12H84a12 12 0 0 1-12-12v-48a12 12 0 0 1 12-12Zm18 16v40l36-20-36-20Z"/>
+  
+  <!-- Dragon body -->
+  <ellipse cx="50" cy="60" rx="18" ry="12" fill="url(#dragonBody)" />
+  
+  <!-- Dragon belly -->
+  <ellipse cx="50" cy="62" rx="12" ry="9" fill="url(#dragonBelly)" />
+  
+  <!-- Dragon head -->
+  <circle cx="50" cy="45" r="10" fill="url(#dragonBody)" />
+  
+  <!-- Dragon eyes -->
+  <circle cx="47" cy="42" r="1.5" fill="#32CD32" />
+  <circle cx="53" cy="42" r="1.5" fill="#32CD32" />
+  <!-- Winking right eye -->
+  <path d="M 51 42 Q 52.5 43 54 42" stroke="#32CD32" stroke-width="1" fill="none" />
+  
+  <!-- Dragon mouth -->
+  <path d="M 45 48 Q 50 50 55 48" stroke="#32CD32" stroke-width="1" fill="none" />
+  
+  <!-- Dragon fangs -->
+  <polygon points="48,48 49,51 50,48" fill="white" />
+  <polygon points="50,48 51,51 52,48" fill="white" />
+  
+  <!-- Dragon wings -->
+  <ellipse cx="40" cy="52" rx="6" ry="4" fill="#D2691E" transform="rotate(-20 40 52)" />
+  <ellipse cx="60" cy="52" rx="6" ry="4" fill="#D2691E" transform="rotate(20 60 52)" />
+  
+  <!-- Dragon tail -->
+  <path d="M 32 60 Q 25 65 20 62" stroke="url(#dragonBody)" stroke-width="4" fill="none" stroke-linecap="round" />
+  
+  <!-- Dragon arms -->
+  <ellipse cx="42" cy="58" rx="3" ry="6" fill="url(#dragonBody)" transform="rotate(-20 42 58)" />
+  <ellipse cx="58" cy="58" rx="3" ry="6" fill="url(#dragonBody)" transform="rotate(20 58 58)" />
+  
+  <!-- Jester hat -->
+  <g fill="#FFD700">
+    <polygon points="50,35 45,30 50,28 55,30" fill="#FF0000" />
+    <polygon points="50,35 47.5,30 50,28 52.5,30" fill="#0000FF" />
+    <polygon points="50,35 46,30 50,28 54,30" fill="#FFFF00" />
   </g>
+  
+  <!-- Hat bells -->
+  <circle cx="45" cy="30" r="1" fill="#FFD700" />
+  <circle cx="50" cy="28" r="1" fill="#FFD700" />
+  <circle cx="55" cy="30" r="1" fill="#FFD700" />
 </svg>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,97 @@
+<svg viewBox="0 0 400 200" xmlns="http://www.w3.org/2000/svg">
+  <!-- Rainbow background -->
+  <defs>
+    <linearGradient id="rainbow" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#ff0000;stop-opacity:1" />
+      <stop offset="16.66%" style="stop-color:#ff7f00;stop-opacity:1" />
+      <stop offset="33.33%" style="stop-color:#ffff00;stop-opacity:1" />
+      <stop offset="50%" style="stop-color:#00ff00;stop-opacity:1" />
+      <stop offset="66.66%" style="stop-color:#0000ff;stop-opacity:1" />
+      <stop offset="83.33%" style="stop-color:#4b0082;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#9400d3;stop-opacity:1" />
+    </linearGradient>
+    
+    <!-- Dragon gradient -->
+    <linearGradient id="dragonBody" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#90EE90;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#32CD32;stop-opacity:1" />
+    </linearGradient>
+    
+    <!-- Dragon belly gradient -->
+    <linearGradient id="dragonBelly" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#FFFACD;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#F5DEB3;stop-opacity:1" />
+    </linearGradient>
+    
+    <!-- Text gradient -->
+    <linearGradient id="textGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#ff7f00;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#9400d3;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  
+  <!-- Rainbow arc -->
+  <path d="M 50 120 Q 200 40 350 120" stroke="url(#rainbow)" stroke-width="8" fill="none" stroke-linecap="round"/>
+  
+  <!-- Stars/Sparkles -->
+  <g fill="#ff7f00">
+    <polygon points="80,60 85,70 95,70 87,77 90,87 80,82 70,87 73,77 65,70 75,70" />
+    <polygon points="320,50 325,60 335,60 327,67 330,77 320,72 310,77 313,67 305,60 315,60" />
+    <polygon points="150,30 153,36 159,36 155,40 157,46 150,43 143,46 145,40 141,36 147,36" />
+    <polygon points="250,25 253,31 259,31 255,35 257,41 250,38 243,41 245,35 241,31 247,31" />
+  </g>
+  
+  <!-- Dragon body -->
+  <ellipse cx="200" cy="100" rx="35" ry="25" fill="url(#dragonBody)" />
+  
+  <!-- Dragon belly -->
+  <ellipse cx="200" cy="105" rx="25" ry="18" fill="url(#dragonBelly)" />
+  
+  <!-- Dragon head -->
+  <circle cx="200" cy="85" r="20" fill="url(#dragonBody)" />
+  
+  <!-- Dragon eyes -->
+  <circle cx="195" cy="80" r="3" fill="#32CD32" />
+  <circle cx="205" cy="80" r="3" fill="#32CD32" />
+  <!-- Winking right eye -->
+  <path d="M 202 80 Q 205 82 208 80" stroke="#32CD32" stroke-width="2" fill="none" />
+  
+  <!-- Dragon mouth -->
+  <path d="M 190 90 Q 200 95 210 90" stroke="#32CD32" stroke-width="2" fill="none" />
+  
+  <!-- Dragon fangs -->
+  <polygon points="195,90 197,95 199,90" fill="white" />
+  <polygon points="201,90 203,95 205,90" fill="white" />
+  
+  <!-- Dragon wings -->
+  <ellipse cx="180" cy="95" rx="12" ry="8" fill="#D2691E" transform="rotate(-20 180 95)" />
+  <ellipse cx="220" cy="95" rx="12" ry="8" fill="#D2691E" transform="rotate(20 220 95)" />
+  
+  <!-- Dragon tail -->
+  <path d="M 165 100 Q 150 110 140 105" stroke="url(#dragonBody)" stroke-width="8" fill="none" stroke-linecap="round" />
+  
+  <!-- Dragon arms -->
+  <ellipse cx="185" cy="105" rx="6" ry="12" fill="url(#dragonBody)" transform="rotate(-20 185 105)" />
+  <ellipse cx="215" cy="105" rx="6" ry="12" fill="url(#dragonBody)" transform="rotate(20 215 105)" />
+  
+  <!-- Jester hat -->
+  <g fill="#FFD700">
+    <polygon points="200,65 190,55 200,50 210,55" fill="#FF0000" />
+    <polygon points="200,65 195,55 200,50 205,55" fill="#0000FF" />
+    <polygon points="200,65 192,55 200,50 208,55" fill="#FFFF00" />
+  </g>
+  
+  <!-- Hat bells -->
+  <circle cx="190" cy="55" r="2" fill="#FFD700" />
+  <circle cx="200" cy="50" r="2" fill="#FFD700" />
+  <circle cx="210" cy="55" r="2" fill="#FFD700" />
+  
+  <!-- GIF text -->
+  <text x="240" y="85" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="#2563eb" stroke="white" stroke-width="1">GIF</text>
+  
+  <!-- Giffer title -->
+  <text x="200" y="150" font-family="Arial, sans-serif" font-size="24" font-weight="bold" fill="url(#textGradient)" stroke="white" stroke-width="1" text-anchor="middle">Giffer</text>
+  
+  <!-- Tagline -->
+  <text x="200" y="170" font-family="Arial, sans-serif" font-size="10" font-weight="normal" fill="#333" text-anchor="middle">WHERE EVERY BLINK BECOMES A BRILLIANT BOOP-DE-DOO!</text>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -411,7 +411,9 @@ export default function App() {
         }
       }}
     >
-      <h1>PWA GIF Maker</h1>
+      <div className="app-header">
+        <img src="/logo.svg" alt="Giffer Logo" className="app-logo" />
+      </div>
       {isSharedFile && (
         <div className="card" style={{ backgroundColor: '#10b981', color: 'white', marginBottom: '12px' }}>
           <div style={{ fontWeight: 'bold' }}>

--- a/src/styles.css
+++ b/src/styles.css
@@ -92,3 +92,16 @@ video, canvas, img { max-width: 100%; border-radius: 8px; }
 .timeline-info span {
   font-weight: 500;
 }
+
+/* App Header and Logo Styles */
+.app-header {
+  text-align: center;
+  margin-bottom: 24px;
+}
+
+.app-logo {
+  height: 60px;
+  width: auto;
+  max-width: 100%;
+  object-fit: contain;
+}


### PR DESCRIPTION
Add a new Giffer logo to the app header and a cropped dragon PWA icon, updating app branding accordingly.

---
<a href="https://cursor.com/background-agent?bcId=bc-1567a8f3-4ab1-461b-921b-6b5cb05d3c59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1567a8f3-4ab1-461b-921b-6b5cb05d3c59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

